### PR TITLE
Add background music

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <audio id="bgm" src="audio/kakuge.mp3" loop></audio>
     <div class="game-container">
         <!-- ゲーム情報表示 -->
         <div class="game-info" id="game-info" style="display: none;">
@@ -118,6 +119,7 @@
         // ゲーム設定
         const canvas = document.getElementById('gameCanvas');
         const ctx = canvas.getContext('2d');
+        const bgm = document.getElementById('bgm');
 
         // ゲーム状態
         let gameState = {
@@ -756,7 +758,11 @@
             document.querySelector('.pause-btn').style.display = 'block';
             document.querySelector('.fullscreen-btn').style.display = 'block';
             document.querySelector('.settings-btn').style.display = 'block';
-            
+            if (bgm) {
+                bgm.currentTime = 0;
+                bgm.play();
+            }
+
             // キャンバスサイズ調整
             resizeCanvas();
             

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 // ゲーム設定
 const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
+const bgm = document.getElementById('bgm');
 
 // ゲーム状態
 let gameState = {
@@ -872,6 +873,10 @@ function initGame() {
 function startGame() {
     const startScreen = document.getElementById('start-screen');
     startScreen.style.display = 'none';
+    if (bgm) {
+        bgm.currentTime = 0;
+        bgm.play();
+    }
     initGame();
 }
 
@@ -880,12 +885,14 @@ window.addEventListener('resize', resizeCanvas);
 
 // ページ読み込み完了後に初期表示を準備
 document.addEventListener('DOMContentLoaded', () => {
-    // 初期状態ではゲームを開始しない
     const volumeSlider = document.getElementById('volume-slider');
     const volumeValue = document.getElementById('volume-value');
-    volumeSlider.addEventListener('input', () => {
-        volumeValue.textContent = volumeSlider.value;
-    });
+    if (volumeSlider && volumeValue) {
+        volumeSlider.addEventListener('input', () => {
+            volumeValue.textContent = volumeSlider.value;
+            if (bgm) bgm.volume = volumeSlider.value;
+        });
+    }
 });
 
 function pauseGame() {


### PR DESCRIPTION
## Summary
- Add background music element and playback logic for kakuge.mp3
- Initialize and play music on game start; expose volume hook

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895ca4e49cc83308b3c0db856cd75ae