### PR TITLE
Add mobile touch controller at bottom

### DIFF
--- a/index.html
+++ b/index.html
@@ -765,7 +765,10 @@
 
             // キャンバスサイズ調整
             resizeCanvas();
-            
+
+            // モバイル向けタッチコントローラーを表示
+            setupTouchControls();
+
             // ゲーム初期化
             resetPlayers();
             updateHealthBars();


### PR DESCRIPTION
## Summary
- show touch controls at bottom when starting game for mobile screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689716ab15c8833098df2d3315b8933a